### PR TITLE
Removes prototype scope and redundant bean comparison

### DIFF
--- a/src/main/java/com/dj/springcoredemo/common/CricketCoach.java
+++ b/src/main/java/com/dj/springcoredemo/common/CricketCoach.java
@@ -1,11 +1,8 @@
 package com.dj.springcoredemo.common;
 
-import org.springframework.beans.factory.config.ConfigurableBeanFactory;
-import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
 @Component
-@Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
 public class CricketCoach implements Coach{
 
     public CricketCoach() {

--- a/src/main/java/com/dj/springcoredemo/rest/DemoController.java
+++ b/src/main/java/com/dj/springcoredemo/rest/DemoController.java
@@ -12,24 +12,17 @@ public class DemoController {
 
     // define a private field for the dependency
     private Coach myCoach;
-    private Coach anotherCoach;
 
     @Autowired
-    public DemoController(@Qualifier("cricketCoach") Coach theCoach, @Qualifier("cricketCoach") Coach theAnotherCoach) {
+    public DemoController(@Qualifier("cricketCoach") Coach theCoach){
 
         System.out.println("In constructor: " + getClass().getSimpleName());
         myCoach = theCoach;
-        anotherCoach = theAnotherCoach;
     }
 
     @GetMapping("/dailyworkout")
     public String getDailyWorkout(){
         return myCoach.getDailyWorkout();
     };
-
-    @GetMapping("/check")
-    public String check(){
-        return "Comparing beans: myCoach == anotherCoach, " + (myCoach == anotherCoach);
-    }
 
 }


### PR DESCRIPTION
Eliminates the prototype scope annotation from CricketCoach class, making it singleton by default.

Updates DemoController to simplify constructor injection by removing the second bean dependency. Also removes the `/check` endpoint, which compared two bean instances, as it is no longer relevant.